### PR TITLE
Make peerDependencies more universal, update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,24 +21,24 @@
     "ts-babel-node": "bin/ts-babel-node.js"
   },
   "peerDependencies": {
-    "typescript": ">= 1.5.0 < 2"
+    "typescript": "*",
+    "ts-node": "*"
   },
   "devDependencies": {
-    "bluebird": "^3.3.4",
-    "code": "^2.2.0",
+    "bluebird": "^3.4.0",
+    "code": "^3.0.1",
     "concat-stream": "^1.5.1",
-    "eslint": "^2.7.0",
-    "lab": "^10.3.1",
+    "eslint": "^2.12.0",
+    "lab": "^10.7.1",
     "merge2": "^1.0.2",
-    "tslint-eslint-rules": "^1.2.0",
-    "typescript": "^1.8.9",
-    "typings": "^0.7.12"
+    "tslint-eslint-rules": "^1.3.0",
+    "typescript": "^1.8.10",
+    "typings": "^1.0.5"
   },
   "dependencies": {
-    "babel-core": "^6.7.6",
-    "babel-polyfill": "^6.7.4",
-    "babel-preset-es2015": "^6.6.0",
-    "source-map-support": "^0.4.0",
-    "ts-node": "^0.7.1"
+    "babel-core": "^6.9.1",
+    "babel-polyfill": "^6.9.1",
+    "babel-preset-es2015": "^6.9.0",
+    "source-map-support": "^0.4.0"
   }
 }


### PR DESCRIPTION
It would be messy for you to update this package with every release of `ts-node` (which just happened). I've moved it to peerDependencies with the range of `*` and updated other deps. Hope that's okay.