### PR TITLE
[sourcemap] Actually remove comments from TS output.

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ function hook(base, m, filename) {
 
 function compile(base, code, filename) {
   var sourcemap = convertSourceMap.fromMapFileSource(code, '.').toObject();
-  convertSourceMap.removeMapFileComments(code);
+  code = convertSourceMap.removeMapFileComments(code);
 
   var babelOutput = babel.transform(code, getBabelOpts(filename, sourcemap));
 
@@ -112,7 +112,7 @@ function overrideSourceMaps() {
 
 function wrap(base, fn) {
   if (!(typeof base === 'function')) return base;
-  return function ()  {
+  return function () {
     var args = Array.prototype.slice.call(arguments, 0);
     args.unshift(base);
     return fn.apply(this, args);

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "convert-source-map": "^1.3.0",
     "error-stack-parser": "^1.3.6",
     "eslint": "^3.8.1",
-    "lab": "^11.1.0",
+    "lab": "^13.1.0",
     "merge2": "^1.0.2",
     "ts-node": "^1.6.0",
     "tslint": "^3.15.1",


### PR DESCRIPTION
The API wasn’t being used correctly previously. I didn’t see an obvious way to test this without adding unit tests to the test suite, which isn’t being done atm, let me know what you would prefer or if this is good enough.