### PR TITLE
Updated to ts-node 3.2.1, changed to support inline source-maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,16 @@ import 'ts-babel-node/register-babel';
 ```
 
 Then use `gulp` normally. Keep in mind that the babel transpiler won't be active in your `gulpfile.ts`, but will be running in all your imports.
+
+### Debugging
+
+In order to debug with `ts-babel-node` you must run with one of the following options:
+
+```
+> node [debug_opts] -r ts-babel-node/register [args]
+> node [debug_opts] node_modules/.bin/ts-babel-node [args]
+
+```
+
+This is a current limitation due to this module not spawning it's own node process, so debug
+arguments aren't passed to node as execArgs, instead they're passed as normal script arguments.

--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ function hook(base, m, filename) {
 }
 
 function compile(base, code, filename) {
-  var sourcemap = convertSourceMap.fromMapFileSource(code, '.').toObject();
+  var sourcemap = convertSourceMap.fromSource(code).toObject();
   code = convertSourceMap.removeMapFileComments(code);
 
   var babelOutput = babel.transform(code, getBabelOpts(filename, sourcemap));

--- a/index.js
+++ b/index.js
@@ -1,20 +1,23 @@
 'use strict';
 
+var os = require('os');
 var path = require('path');
 var babel = require('babel-core');
 var buildConfigChain = require('babel-core/lib/transformation/file/options/build-config-chain');
 var sourceMapSupport = require('source-map-support');
 var convertSourceMap = require('convert-source-map');
+var mergeSourceMap = require('merge-source-map');
 
 var outputs = {}; // filename => { code, map }
 
-var baseBabelOpts = { ast: false };
+var baseBabelOpts = { ast: false, sourceMaps: true };
 
 var defaultBabelOpts = {
   presets: [ require('babel-preset-env') ],
 };
 
 exports.registerBabel = registerBabel;
+
 function registerBabel(babelOpts) {
   if (babelOpts) {
     Object.assign(baseBabelOpts, babelOpts);
@@ -42,6 +45,7 @@ function registerBabel(babelOpts) {
 }
 
 exports.register = register;
+
 function register(tsNodeOpts, babelOpts) {
   registerBabel(babelOpts);
   require('ts-node').register(tsNodeOpts);
@@ -53,26 +57,42 @@ function hook(base, m, filename) {
 }
 
 function compile(base, code, filename) {
-  var sourcemap = convertSourceMap.fromSource(code).toObject();
+  var sourceMapConverter = convertSourceMap.fromSource(code);
+  var originalSourceMap = null;
+
+  // older versions of ts-node use .map files rather than inline
+  if (!sourceMapConverter) {
+    sourceMapConverter = convertSourceMap.fromMapFileSource(code, '.');
+  }
+
+  if (sourceMapConverter) {
+    originalSourceMap = sourceMapConverter.toObject();
+  }
+
   code = convertSourceMap.removeMapFileComments(code);
 
-  var babelOutput = babel.transform(code, getBabelOpts(filename, sourcemap));
+  var babelOutput = babel.transform(code, getBabelOpts(filename));
+  var mergedSourceMap = buildSourceMap(originalSourceMap, babelOutput.map, filename);
 
   // babelOutput has a bunch of undocumented stuff on it. Just grab what we need to save memory
-  outputs[filename] = { code: babelOutput.code, map: babelOutput.map };
+  outputs[filename] = { code: babelOutput.code, map: mergedSourceMap };
 
-  return base.call(this, babelOutput.code, filename);
+  var codeWithSourceMap = attachInlineSourceMap(babelOutput.code, mergedSourceMap);
+  return base.call(this, codeWithSourceMap, filename);
 }
 
-function getBabelOpts(filename, sourcemap) {
+function getBabelOpts(filename) {
   // this function does roughly what OptionsManager.init does, but we add our own defaulting logic
 
-  var chain = buildConfigChain(Object.assign({ filename: filename, inputSourceMap: sourcemap }, baseBabelOpts));
+  var chain = buildConfigChain(Object.assign({ filename: filename }, baseBabelOpts));
 
   var optionsManager = new babel.OptionManager();
-  chain.forEach(function (c) { optionsManager.mergeOptions(c); });
+  chain.forEach(function (c) {
+    optionsManager.mergeOptions(c);
+  });
 
-  // custom defaulting logic: If the user doesn't provide a .babelrc (or equivalent), then we supply our default.
+  // custom defaulting logic: If the user doesn't provide a .babelrc (or equivalent), then we supply
+  // our default.
   if (chain.length < 2) // our base config counts as a config
     optionsManager.mergeOptions({
       options: defaultBabelOpts,
@@ -86,8 +106,47 @@ function getBabelOpts(filename, sourcemap) {
   return optionsManager.options;
 }
 
+/**
+ * Merge the original source map (from TS->JS compilation) with the babel source map. This
+ * produces a better result than using the `inputSourceMap` option in babel.
+ *
+ * @param {Object} originalSourceMap the source map associated with the original code
+ * @param {Object} compiledSourceMap the source map outputted from babel
+ * @param {String} filename the path to the original code
+ * @return {Object} Merged source map
+ */
+function buildSourceMap(originalSourceMap, compiledSourceMap, filename) {
+  var mergedMap = mergeSourceMap(originalSourceMap, compiledSourceMap);
+
+  mergedMap.sources = [ filename ];
+  // we've compile the sources so it should be a '.js' file now
+  mergedMap.file = replaceExtension(filename);
+
+  if (mergedMap.sourceRoot) {
+    delete mergedMap.sourceRoot;
+  }
+
+  return mergedMap;
+
+  function replaceExtension(str) {
+    return str.replace(/\..+$/, '.js');
+  }
+}
+
+/**
+ * Debuggers need access to the source maps to work correctly. Since we're not writing them to
+ * disk we write inline source maps to the code
+ * @param {String} code
+ * @param {Object} sourceMap
+ * @returns {String} code with inline source map as a comment
+ */
+function attachInlineSourceMap(code, sourceMap) {
+  return code + os.EOL + convertSourceMap.fromObject(sourceMap).toComment();
+}
+
 function overrideSourceMaps() {
   sourceMapSupport.install({
+    environment: 'node',
     handleUncaughtExceptions: false,
     retrieveFile: function (filename) {
       return outputs && outputs[filename] && outputs[filename].code;
@@ -109,7 +168,8 @@ function overrideSourceMaps() {
   });
 
   // Prevent ts-node from adding its own lookups.
-  sourceMapSupport.install = function () { };
+  sourceMapSupport.install = function () {
+  };
 }
 
 function wrap(base, fn) {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "ts-babel-node": "bin/ts-babel-node.js"
   },
   "peerDependencies": {
-    "ts-node": ">=0.9",
+    "ts-node": ">=3.2.1",
     "typescript": "*"
   },
   "devDependencies": {
@@ -45,6 +45,7 @@
   "dependencies": {
     "babel-core": "^6.9.1",
     "babel-preset-env": "^1.5.2",
+    "merge-source-map": "^1.0.4",
     "source-map-support": "^0.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "eslint": "^3.8.1",
     "lab": "^13.1.0",
     "merge2": "^1.0.2",
-    "ts-node": "^3.0.6",
+    "ts-node": "^3.2.1",
     "tslint": "^3.15.1",
     "tslint-eslint-rules": "^2.1.0",
     "typescript": "^2.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1302,6 +1302,12 @@ make-error@^1.1.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.0.tgz#52ad3a339ccf10ce62b4040b708fe707244b8b96"
 
+merge-source-map@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/merge-source-map/-/merge-source-map-1.0.4.tgz#a5de46538dae84d4114cc5ea02b4772a6346701f"
+  dependencies:
+    source-map "^0.5.6"
+
 merge2@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.0.3.tgz#fa44f8b2262615ab72f0808a401d478a70e394db"

--- a/yarn.lock
+++ b/yarn.lock
@@ -59,6 +59,12 @@ ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
+ansi-styles@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.1.0.tgz#09c202d5c917ec23188caa5c9cb9179cd9547750"
+  dependencies:
+    color-convert "^1.0.0"
+
 argparse@^1.0.7:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.9.tgz#73d83bc263f86e97f8cc4f6bae1b0e90a7d22c86"
@@ -617,6 +623,14 @@ chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
+chalk@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.0.1.tgz#dbec49436d2ae15f536114e76d14656cdbc0f44d"
+  dependencies:
+    ansi-styles "^3.1.0"
+    escape-string-regexp "^1.0.5"
+    supports-color "^4.0.0"
+
 circular-json@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.1.tgz#be8b36aefccde8b3ca7aa2d6afc07a37242c0d2d"
@@ -652,6 +666,16 @@ code@^4.0.0:
   resolved "https://registry.yarnpkg.com/code/-/code-4.1.0.tgz#209ad11d05af8a0c1c7aaf694d9fa4d2c7d95b85"
   dependencies:
     hoek "4.x.x"
+
+color-convert@^1.0.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.0.tgz#1accf97dd739b983bf994d56fec8f95853641b7a"
+  dependencies:
+    color-name "^1.1.1"
+
+color-name@^1.1.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
 
 colors@^1.1.2:
   version "1.1.2"
@@ -1038,6 +1062,10 @@ has-ansi@^2.0.0:
   resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
   dependencies:
     ansi-regex "^2.0.0"
+
+has-flag@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
 
 hoek@4.x.x:
   version "4.1.1"
@@ -1615,6 +1643,12 @@ supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
+supports-color@^4.0.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.2.0.tgz#ad986dc7eb2315d009b4d77c8169c2231a684037"
+  dependencies:
+    has-flag "^2.0.0"
+
 table@^3.7.8:
   version "3.8.3"
   resolved "https://registry.yarnpkg.com/table/-/table-3.8.3.tgz#2bbc542f0fda9861a755d3947fefd8b3f513855f"
@@ -1652,19 +1686,19 @@ tryit@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tryit/-/tryit-1.0.3.tgz#393be730a9446fd1ead6da59a014308f36c289cb"
 
-ts-node@^3.0.6:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-3.0.6.tgz#55127ff790c7eebf6ba68c1e6dde94b09aaa21e0"
+ts-node@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-3.2.1.tgz#9595dd840d03e62bc79214ce5a7b51e55e3c4ffc"
   dependencies:
     arrify "^1.0.0"
-    chalk "^1.1.1"
+    chalk "^2.0.0"
     diff "^3.1.0"
     make-error "^1.1.1"
     minimist "^1.2.0"
     mkdirp "^0.5.1"
     source-map-support "^0.4.0"
     tsconfig "^6.0.0"
-    v8flags "^2.0.11"
+    v8flags "^3.0.0"
     yn "^2.0.0"
 
 tsconfig@^6.0.0:
@@ -1741,9 +1775,9 @@ util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
 
-v8flags@^2.0.11:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/v8flags/-/v8flags-2.1.1.tgz#aab1a1fa30d45f88dd321148875ac02c0b55e5b4"
+v8flags@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/v8flags/-/v8flags-3.0.0.tgz#4be9604488e0c4123645def705b1848d16b8e01f"
   dependencies:
     user-home "^1.1.1"
 


### PR DESCRIPTION
As discussed in issue https://github.com/danielmoore/ts-babel-node/issues/15, ts-node changed to use inline source-maps which broke source-map support for ts-babel-node.

